### PR TITLE
Update fswatcher.config

### DIFF
--- a/scripts/fswatcher.config
+++ b/scripts/fswatcher.config
@@ -55,7 +55,7 @@ USE_FALLBACK=true
 # FILE_LOGGING=false
 
 # Log Directory (If you'd like to persist the log to your host system)
-# LOG_DIR=~/fswatcher_log
+LOG_DIR=~/fswatcher_log
 
 # Boto3 Logging, enables Botocore logging for more in depth logs
 # BOTO3_LOGGING=false


### PR DESCRIPTION
If the 'LOG_DIR=~/fswatcher_log' variable is not uncommented, the docker container fails to start with the following error:

docker: invalid spec: :/fswatcher/logs: empty section between colons