### PR TITLE
Update fswatcher.config

### DIFF
--- a/scripts/fswatcher.config
+++ b/scripts/fswatcher.config
@@ -55,7 +55,7 @@ USE_FALLBACK=true
 # FILE_LOGGING=false
 
 # Log Directory (If you'd like to persist the log to your host system)
-LOG_DIR=~/fswatcher_log
+LOG_DIR=$(cd .. && pwd)
 
 # Boto3 Logging, enables Botocore logging for more in depth logs
 # BOTO3_LOGGING=false


### PR DESCRIPTION
I suggest moving the default path for the fswatcher.log file into the application (../fswatcher/fswatcher.log) directory. This provides the following benefits:

- The fswatcher application is more portable as all of the application files and logs are now in the same directory 
- The fswatcher application can now be more easily customized to run parallel installations. Without moving the logging into the fswatcher application directory, the logs are all written to the user's home directory. This becomes problematic when running numerous fswatcher docker containers.