### PR TITLE
Update fswatcher.config

### DIFF
--- a/scripts/fswatcher.config
+++ b/scripts/fswatcher.config
@@ -52,7 +52,7 @@ USE_FALLBACK=true
 # Logging configurations
 # ========================
 # File Logging (If you'd like to store a log file within the container)
-# FILE_LOGGING=false
+# FILE_LOGGING=true
 
 # Log Directory (If you'd like to persist the log to your host system)
 LOG_DIR=$(cd .. && pwd)


### PR DESCRIPTION
Updated the FILE_LOGGING parameter default from 'false' to 'true'. By default, the parameter is commented out thus disabling the file logging. Shipping the parameter as 'false' by default is redundant. If the default is set to 'true', the user only needs to uncomment the line and logging will be enabled when initially configuring the application.