### PR TITLE
Update fswatcher.config

### DIFF
--- a/scripts/fswatcher.config
+++ b/scripts/fswatcher.config
@@ -12,7 +12,8 @@ IMAGE_NAME=fswatcher
 # ========================
 # AWS configurations
 # ========================
-# S3 bucket name (Note:Support directories as well s3-bucket-name/directory)
+# S3 bucket name (Note: Directories are supported. Use the following syntax: s3-bucket-name/directory)
+# If the directory does not already exist in S3, the directory structure will be created when the file is synced
 S3_BUCKET_NAME=s3_bucket_name
 
 # AWS region (Used for Timestream Database)


### PR DESCRIPTION
- Testing reveals that the directory structure is created only when a file is synced, not when the Docker container is started. Added clarification to prevent confusion.
- Minor language improvement to clarify how to specify directories in the fswatcher.config file.